### PR TITLE
create Policy.from_string and tests

### DIFF
--- a/glasswall/__init__.py
+++ b/glasswall/__init__.py
@@ -4,7 +4,7 @@ import os
 import platform
 import tempfile
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 
 _OPERATING_SYSTEM = platform.system()
 _PYTHON_VERSION = platform.python_version()

--- a/glasswall/content_management/config_elements/pdfConfig.py
+++ b/glasswall/content_management/config_elements/pdfConfig.py
@@ -14,9 +14,10 @@ class pdfConfig(ConfigElement):
     pdfConfig(default="allow", embedded_images="sanitise")
     """
 
-    def __init__(self, default: str = "sanitise", **kwargs):
+    def __init__(self, default: str = "sanitise", attributes: dict = {}, **kwargs):
         self.name = self.__class__.__name__
         self.default = default
+        self.attributes = attributes
         self.switches_module = switches.pdf
         self.default_switches = [
             self.switches_module.acroform(value=default),
@@ -33,6 +34,7 @@ class pdfConfig(ConfigElement):
         super().__init__(
             name=self.name,
             default=self.default,
+            attributes=self.attributes,
             switches_module=self.switches_module,
             default_switches=self.default_switches,
             config=kwargs

--- a/glasswall/content_management/config_elements/pptConfig.py
+++ b/glasswall/content_management/config_elements/pptConfig.py
@@ -14,9 +14,10 @@ class pptConfig(ConfigElement):
     pptConfig(default="allow", embedded_images="sanitise")
     """
 
-    def __init__(self, default: str = "sanitise", **kwargs):
+    def __init__(self, default: str = "sanitise", attributes: dict = {}, **kwargs):
         self.name = self.__class__.__name__
         self.default = default
+        self.attributes = attributes
         self.switches_module = switches.ppt
         self.default_switches = [
             self.switches_module.embedded_files(value=default),
@@ -32,6 +33,7 @@ class pptConfig(ConfigElement):
         super().__init__(
             name=self.name,
             default=self.default,
+            attributes=self.attributes,
             switches_module=self.switches_module,
             default_switches=self.default_switches,
             config=kwargs

--- a/glasswall/content_management/config_elements/sysConfig.py
+++ b/glasswall/content_management/config_elements/sysConfig.py
@@ -11,8 +11,9 @@ class sysConfig(ConfigElement):
     sysConfig(interchange_type="xml", interchange_pretty="false")
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, attributes={}, **kwargs):
         self.name = self.__class__.__name__
+        self.attributes = attributes
         self.switches_module = switches.sys
         self.default_switches = [
             self.switches_module.interchange_type(value="sisl"),
@@ -21,6 +22,7 @@ class sysConfig(ConfigElement):
 
         super().__init__(
             name=self.name,
+            attributes=self.attributes,
             switches_module=self.switches_module,
             default_switches=self.default_switches,
             config=kwargs

--- a/glasswall/content_management/config_elements/textSearchConfig.py
+++ b/glasswall/content_management/config_elements/textSearchConfig.py
@@ -51,8 +51,11 @@ class textSearchConfig(ConfigElement):
             # Append constructed config_element to subelements
             subelements.append(config_element)
 
-        self.subelements = [
-            textList(subelements=subelements)
-        ]
+        if subelements:
+            self.subelements = [
+                textList(subelements=subelements)
+            ]
+        else:
+            self.subelements = []
 
         super().__init__(name=self.name, attributes=self.attributes, subelements=self.subelements)

--- a/glasswall/content_management/config_elements/tiffConfig.py
+++ b/glasswall/content_management/config_elements/tiffConfig.py
@@ -14,9 +14,10 @@ class tiffConfig(ConfigElement):
     tiffConfig(geotiff="sanitise")
     """
 
-    def __init__(self, default: str = "sanitise", **kwargs):
+    def __init__(self, default: str = "sanitise", attributes={}, **kwargs):
         self.name = self.__class__.__name__
         self.default = default
+        self.attributes = attributes
         self.switches_module = switches.tiff
         self.default_switches = [
             self.switches_module.geotiff(value=default),
@@ -25,6 +26,7 @@ class tiffConfig(ConfigElement):
         super().__init__(
             name=self.name,
             default=self.default,
+            attributes=self.attributes,
             switches_module=self.switches_module,
             default_switches=self.default_switches,
             config=kwargs

--- a/glasswall/content_management/config_elements/wordConfig.py
+++ b/glasswall/content_management/config_elements/wordConfig.py
@@ -14,9 +14,10 @@ class wordConfig(ConfigElement):
     wordConfig(default="allow", embedded_images="sanitise")
     """
 
-    def __init__(self, default: str = "sanitise", **kwargs):
+    def __init__(self, default: str = "sanitise", attributes: dict = {}, **kwargs):
         self.name = self.__class__.__name__
         self.default = default
+        self.attributes = attributes
         self.switches_module = switches.word
         self.default_switches = [
             self.switches_module.dynamic_data_exchange(value=default),
@@ -32,6 +33,7 @@ class wordConfig(ConfigElement):
         super().__init__(
             name=self.name,
             default=self.default,
+            attributes=self.attributes,
             switches_module=self.switches_module,
             default_switches=self.default_switches,
             config=kwargs

--- a/glasswall/content_management/config_elements/xlsConfig.py
+++ b/glasswall/content_management/config_elements/xlsConfig.py
@@ -14,9 +14,10 @@ class xlsConfig(ConfigElement):
     xlsConfig(default="allow", embedded_images="sanitise")
     """
 
-    def __init__(self, default: str = "sanitise", **kwargs):
+    def __init__(self, default: str = "sanitise", attributes: dict = {}, **kwargs):
         self.name = self.__class__.__name__
         self.default = default
+        self.attributes = attributes
         self.switches_module = switches.xls
         self.default_switches = [
             self.switches_module.dynamic_data_exchange(value=default),
@@ -32,6 +33,7 @@ class xlsConfig(ConfigElement):
         super().__init__(
             name=self.name,
             default=self.default,
+            attributes=self.attributes,
             switches_module=self.switches_module,
             default_switches=self.default_switches,
             config=kwargs

--- a/glasswall/content_management/policies/policy.py
+++ b/glasswall/content_management/policies/policy.py
@@ -315,12 +315,12 @@ class Policy:
                 # Create custom config element
                 new_config_element = glasswall.content_management.config_elements.ConfigElement(name=config_element.tag, attributes=config_element.attrib)
 
-            for switch in config_element:
+            for item in config_element:
                 # Add children, e.g. textList has child elements: textItem
-                if switch.getchildren():
-                    # if getchildren() then switch is actually a config element, such as textList
-                    textList = glasswall.content_management.config_elements.ConfigElement(name=switch.tag, attributes=switch.attrib)
-                    for textItem in switch.getchildren():
+                if item.getchildren():
+                    # if getchildren() then item is a config element, such as textList
+                    textList = glasswall.content_management.config_elements.ConfigElement(name=item.tag, attributes=item.attrib)
+                    for textItem in item.getchildren():
                         new_textItem = glasswall.content_management.config_elements.ConfigElement(name=textItem.tag, attributes=textItem.attrib)
                         for switch in textItem:
                             new_textItem.add_switch(glasswall.content_management.switches.Switch(name=switch.tag, value=switch.text, attributes=switch.attrib))
@@ -328,11 +328,12 @@ class Policy:
                     new_config_element.subelements.append(textList)
                     continue
 
-                if hasattr(new_config_element.switches_module, switch.tag):
+                # if not getchildren() then item is a switch
+                if hasattr(new_config_element.switches_module, item.tag):
                     # Known switch exists, e.g. pdf.internal_hyperlinks
-                    new_switch = getattr(new_config_element.switches_module, switch.tag)(value=switch.text)
+                    new_switch = getattr(new_config_element.switches_module, item.tag)(value=item.text)
                 else:
-                    new_switch = glasswall.content_management.switches.Switch(name=switch.tag, value=switch.text, attributes=switch.attrib)
+                    new_switch = glasswall.content_management.switches.Switch(name=item.tag, value=item.text, attributes=item.attrib)
                 new_config_element.add_switch(new_switch)
 
             new_policy.add_config_element(new_config_element)

--- a/tests/content_management/test_policy.py
+++ b/tests/content_management/test_policy.py
@@ -678,6 +678,84 @@ class TestPolicy(unittest.TestCase):
         # replacementChar attribute exists
         self.assertTrue(policy.textSearchConfig.textList.subelements[0].switches[1].attributes.get("replacementChar") == "*")
 
+    def test_policy_from_string(self):
+        policies_to_test = [
+            glasswall.content_management.policies.ArchiveManager(
+                default="sanitise",
+                default_archive_manager="process",
+                config={
+                    "pdfConfig": {"embeddedImages": "disallow"},
+                    "wordConfig": {"embeddedImages": "disallow"},
+                    "archiveConfig": {
+                        "@recursionDepth": "50",
+                        "jpeg": "discard"
+                    }
+                }
+            ),
+            glasswall.content_management.policies.Editor(
+                default="allow",
+                config={
+                    "sysConfig": {
+                        "interchange_type": "sisl",
+                        "interchange_pretty": "true",
+                    },
+                    "xlsConfig": {
+                        "external_hyperlinks": "sanitise",
+                        "internal_hyperlinks": "sanitise",
+                    }
+                },
+            ),
+            glasswall.content_management.policies.Rebuild(
+                default="disallow",
+                config={
+                    "sysConfig": {
+                        "interchange_type": "xml",
+                        "interchange_pretty": "false",
+                    },
+                    "pdfConfig": {
+                        "external_hyperlinks": "sanitise",
+                        "internal_hyperlinks": "sanitise",
+                    }
+                },
+            ),
+            glasswall.content_management.policies.WordSearch(
+                default="allow",
+                config={
+                    "textSearchConfig": {
+                        "@libVersion": "core2",
+                        "textList": [
+                            {"name": "textItem", "switches": [
+                                {"name": "text", "value": "password"},
+                                {"name": "textSetting", "@replacementChar": "*", "value": "redact"},
+                            ]},
+                            {"name": "textItem", "switches": [
+                                {"name": "text", "value": "email"},
+                                {"name": "textSetting", "@replacementChar": "*", "value": "redact"},
+                            ]},
+                        ]
+                    }
+                }
+            ),
+            glasswall.content_management.policies.Policy(
+                config={
+                    "customConfig": {
+                        "customSwitch1": "customValue1",
+                        "customSwitch2": "customValue2",
+                    },
+                    "customConfig2": {
+                        "customSwitch3": "customValue3",
+                    }
+                }
+            )
+        ]
+
+        for policy in policies_to_test:
+            # Create a new Policy object from the using the Policy.from_string method
+            policy_from_string = glasswall.content_management.policies.Policy.from_string(policy.text)
+
+            # The two policies should be equal
+            self.assertTrue(policy.text == policy_from_string.text, msg=f"Policy texts not equal:\n{policy.text}\n{policy_from_string.text}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/content_management/test_policy.py
+++ b/tests/content_management/test_policy.py
@@ -678,7 +678,7 @@ class TestPolicy(unittest.TestCase):
         # replacementChar attribute exists
         self.assertTrue(policy.textSearchConfig.textList.subelements[0].switches[1].attributes.get("replacementChar") == "*")
 
-    def test_policy_from_string(self):
+    def test_policy_from_string___policy_strings_equal(self):
         policies_to_test = [
             glasswall.content_management.policies.ArchiveManager(
                 default="sanitise",


### PR DESCRIPTION
Added a staticmethod for Policy objects: `from_string`  to create a Policy object from a string representation of an xml content management policy, or from a file path.